### PR TITLE
Separate runtime and dev dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
           command: |
                   python -m virtualenv env
                   . env/bin/activate
-                  pip install --no-cache-dir -r requirements.txt
+                  pip install --no-cache-dir -r requirements-dev.txt
 
       # - run:
       #     name: Run tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 pytest
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
       - name: Lint with flake8
         run: |
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest==6.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
 requests==2.26.0
-pytest==6.2.4
-typing==3.7.4.3


### PR DESCRIPTION
## Summary
- Moves `pytest` out of `requirements.txt` into a new `requirements-dev.txt`
- Removes `typing` from requirements (built-in since Python 3.7)
- Updates GitHub Actions and CircleCI to install `requirements-dev.txt` for test runs
- Production installs (`pip install -r requirements.txt`) no longer pull in pytest

Closes #4

## Test plan
- [x] Verify CI passes with updated workflow files
- [x] Verify `requirements.txt` only contains `requests`
- [x] Verify `requirements-dev.txt` includes `-r requirements.txt` so it still installs runtime deps
